### PR TITLE
Fix release process regression: synchronize dynamic version handling

### DIFF
--- a/.github/actions/package-plugin/action.yaml
+++ b/.github/actions/package-plugin/action.yaml
@@ -44,6 +44,10 @@ inputs:
     description: Working directory for packaging
     required: false
     default: ${{ github.workspace }}
+  version:
+    description: Plugin version to use (overrides buildspec.json)
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -57,6 +61,7 @@ runs:
         CODESIGN_TEAM: ${{ inputs.codesignTeam }}
         CODESIGN_IDENT_USER: ${{ inputs.codesignUser }}
         CODESIGN_IDENT_PASS: ${{ inputs.codesignPass }}
+        PLUGIN_VERSION_OVERRIDE: ${{ inputs.version }}
       run: |
         : Run macOS Packaging
 
@@ -83,6 +88,8 @@ runs:
       if: runner.os == 'Linux'
       shell: zsh --no-rcs --errexit --pipefail {0}
       working-directory: ${{ inputs.workingDirectory }}
+      env:
+        PLUGIN_VERSION_OVERRIDE: ${{ inputs.version }}
       run: |
         : Run Ubuntu Packaging
         package_args=(
@@ -98,6 +105,8 @@ runs:
     - name: Run Windows Packaging
       if: runner.os == 'Windows'
       shell: pwsh
+      env:
+        PLUGIN_VERSION_OVERRIDE: ${{ inputs.version }}
       run: |
         # Run Windows Packaging
         if ( $Env:RUNNER_DEBUG -ne $null ) {

--- a/.github/scripts/Package-Windows.ps1
+++ b/.github/scripts/Package-Windows.ps1
@@ -46,6 +46,11 @@ function Package {
     $BuildSpec = Get-Content -Path ${BuildSpecFile} -Raw | ConvertFrom-Json
     $ProductName = $BuildSpec.name
     $ProductVersion = $BuildSpec.version
+    
+    # Use version override if provided (for centralized version management)
+    if ($env:PLUGIN_VERSION_OVERRIDE) {
+        $ProductVersion = $env:PLUGIN_VERSION_OVERRIDE
+    }
 
     $OutputName = "${ProductName}-${ProductVersion}-windows-${Target}"
 

--- a/.github/scripts/package-macos
+++ b/.github/scripts/package-macos
@@ -96,6 +96,11 @@ package() {
   local product_version
   read -r product_name product_version <<< \
     "$(jq -r '. | {name, version} | join(" ")' ${buildspec_file})"
+  
+  # Use version override if provided (for centralized version management)
+  if [[ -n "${PLUGIN_VERSION_OVERRIDE}" ]]; then
+    product_version="${PLUGIN_VERSION_OVERRIDE}"
+  fi
 
   local output_name="${product_name}-${product_version}-${host_os}-universal"
 

--- a/.github/scripts/package-ubuntu
+++ b/.github/scripts/package-ubuntu
@@ -146,6 +146,11 @@ ${_usage_host:-}"
   local product_version
   read -r product_name product_version <<< \
     "$(jq -r '. | {name, version} | join(" ")' ${buildspec_file})"
+  
+  # Use version override if provided (for centralized version management)
+  if [[ -n "${PLUGIN_VERSION_OVERRIDE}" ]]; then
+    product_version="${PLUGIN_VERSION_OVERRIDE}"
+  fi
 
   local -a cmake_args=()
   if (( _loglevel > 1 )) cmake_args+=(--verbose)

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -68,7 +68,13 @@ jobs:
 
           plugin_name="$(jq -r '.name' buildspec.json)"
           plugin_display_name="$(jq -r '.displayName // empty' buildspec.json)"
-          plugin_version="$(jq -r '.version' buildspec.json)"
+          
+          # For PR builds, use development version to match CMake behavior
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            plugin_version="dev"
+          else
+            plugin_version="$(jq -r '.version' buildspec.json)"
+          fi
 
           if [[ "${plugin_display_name}" ]]; then
             echo "pluginName=${plugin_display_name}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -66,9 +66,9 @@ jobs:
           done
           echo "commitHash=${GITHUB_SHA:0:9}" >> $GITHUB_OUTPUT
 
-          plugin_name="$(grep 'name' buildspec.json | sed -E -e 's/^.+"name":[^"]+"(.+)",?$/\1/g')"
-          plugin_display_name="$(grep 'displayName' buildspec.json | sed -E -e 's/^.+"displayName":[^"]+"(.+)",?$/\1/g' || echo "")"
-          plugin_version="$(grep 'version' buildspec.json | sed -E -e 's/^.+"version":[^"]+"(.+)",?$/\1/g')"
+          plugin_name="$(jq -r '.name' buildspec.json)"
+          plugin_display_name="$(jq -r '.displayName // empty' buildspec.json)"
+          plugin_version="$(jq -r '.version' buildspec.json)"
 
           if [[ "${plugin_display_name}" ]]; then
             echo "pluginName=${plugin_display_name}" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -5,6 +5,9 @@ on:
       pluginName:
         description: Project name detected by parsing build spec file
         value: ${{ jobs.check-event.outputs.pluginName }}
+      pluginVersion:
+        description: Project version detected by parsing build spec file
+        value: ${{ jobs.check-event.outputs.pluginVersion }}
 jobs:
   check-event:
     name: Check GitHub Event Data 🔎
@@ -19,6 +22,7 @@ jobs:
       config: ${{ steps.setup.outputs.config }}
       commitHash: ${{ steps.setup.outputs.commitHash }}
       pluginName: ${{ steps.setup.outputs.pluginName }}
+      pluginVersion: ${{ steps.setup.outputs.pluginVersion }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -64,12 +68,14 @@ jobs:
 
           plugin_name="$(grep 'name' buildspec.json | sed -E -e 's/^.+"name":[^"]+"(.+)",?$/\1/g')"
           plugin_display_name="$(grep 'displayName' buildspec.json | sed -E -e 's/^.+"displayName":[^"]+"(.+)",?$/\1/g' || echo "")"
+          plugin_version="$(grep 'version' buildspec.json | sed -E -e 's/^.+"version":[^"]+"(.+)",?$/\1/g')"
 
           if [[ "${plugin_display_name}" ]]; then
             echo "pluginName=${plugin_display_name}" >> $GITHUB_OUTPUT
           else
             echo "pluginName=${plugin_name}" >> $GITHUB_OUTPUT
           fi
+          echo "pluginVersion=${plugin_version}" >> $GITHUB_OUTPUT
 
   macos-build:
     name: Build for macOS 🍏
@@ -105,12 +111,11 @@ jobs:
           print '::endgroup::'
 
           local product_name
-          local product_version
-          read -r product_name product_version <<< \
-            "$(jq -r '. | {name, version} | join(" ")' buildspec.json)"
+          read -r product_name <<< \
+            "$(jq -r '.name' buildspec.json)"
 
           print "pluginName=${product_name}" >> $GITHUB_OUTPUT
-          print "pluginVersion=${product_version}" >> $GITHUB_OUTPUT
+          print "pluginVersion=${{ needs.check-event.outputs.pluginVersion }}" >> $GITHUB_OUTPUT
 
       - uses: actions/cache/restore@v4
         id: ccache-cache
@@ -197,11 +202,11 @@ jobs:
           : Set Up Environment 🔧
           if [[ "${RUNNER_DEBUG}" ]]; then set -x; fi
 
-          read -r product_name product_version <<< \
-            "$(jq -r '. | {name, version} | join(" ")' buildspec.json)"
+          read -r product_name <<< \
+            "$(jq -r '.name' buildspec.json)"
 
           echo "pluginName=${product_name}" >> $GITHUB_OUTPUT
-          echo "pluginVersion=${product_version}" >> $GITHUB_OUTPUT
+          echo "pluginVersion=${{ needs.check-event.outputs.pluginVersion }}" >> $GITHUB_OUTPUT
 
       - uses: actions/cache/restore@v4
         id: ccache-cache
@@ -272,10 +277,9 @@ jobs:
 
           $BuildSpec = Get-Content -Path buildspec.json -Raw | ConvertFrom-Json
           $ProductName = $BuildSpec.name
-          $ProductVersion = $BuildSpec.version
 
           "pluginName=${ProductName}" >> $env:GITHUB_OUTPUT
-          "pluginVersion=${ProductVersion}" >> $env:GITHUB_OUTPUT
+          "pluginVersion=${{ needs.check-event.outputs.pluginVersion }}" >> $env:GITHUB_OUTPUT
 
       - name: Build Plugin 🧱
         uses: ./.github/actions/build-plugin

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -69,10 +69,17 @@ jobs:
           plugin_name="$(jq -r '.name' buildspec.json)"
           plugin_display_name="$(jq -r '.displayName // empty' buildspec.json)"
           
-          # For PR builds, use development version to match CMake behavior
+          # For PR builds, calculate the same development version that CMake uses
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            # Use simplified "dev" for artifact naming (CMake will use full semantic version)
-            plugin_version="dev"
+            # Match CMake logic: MAJOR.MINOR.(9000 + GITHUB_RUN_NUMBER)
+            base_version="$(jq -r '.version' buildspec.json)"
+            IFS='.' read -r major minor patch <<< "${base_version}"
+            if [[ -n "${GITHUB_RUN_NUMBER}" ]]; then
+              dev_patch=$((9000 + GITHUB_RUN_NUMBER))
+              plugin_version="${major}.${minor}.${dev_patch}"
+            else
+              plugin_version="${major}.${minor}.9999"
+            fi
           else
             plugin_version="$(jq -r '.version' buildspec.json)"
           fi

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -68,7 +68,7 @@ jobs:
 
           plugin_name="$(jq -r '.name' buildspec.json)"
           plugin_display_name="$(jq -r '.displayName // empty' buildspec.json)"
-          
+
           # For PR builds, calculate the same development version that CMake uses
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
             # Match CMake logic: MAJOR.MINOR.(9000 + GITHUB_RUN_NUMBER)
@@ -76,7 +76,7 @@ jobs:
             IFS='.' read -r major minor patch <<< "${base_version}"
             if [[ -n "${GITHUB_RUN_NUMBER}" ]]; then
               run_mod=$((GITHUB_RUN_NUMBER % 1000))  # Limit to 0-999 range
-              dev_patch=$((900 + run_mod))  # Results in 900-1899 range  
+              dev_patch=$((900 + run_mod))  # Results in 900-1899 range
               plugin_version="${major}.${minor}.${dev_patch}"
             else
               plugin_version="${major}.${minor}.999"
@@ -175,6 +175,7 @@ jobs:
           notarize: ${{ fromJSON(needs.check-event.outputs.notarize) && fromJSON(steps.codesign.outputs.haveNotarizationUser) }}
           codesignUser: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
           codesignPass: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
+          version: ${{ needs.check-event.outputs.pluginVersion }}
 
       - name: Upload Artifacts 📡
         uses: actions/upload-artifact@v4
@@ -243,6 +244,7 @@ jobs:
           target: x86_64
           config: ${{ needs.check-event.outputs.config }}
           package: ${{ fromJSON(needs.check-event.outputs.package) }}
+          version: ${{ needs.check-event.outputs.pluginVersion }}
 
       - name: Upload Source Tarball 🗜️
         uses: actions/upload-artifact@v4
@@ -308,6 +310,7 @@ jobs:
           target: x64
           config: ${{ needs.check-event.outputs.config }}
           package: ${{ fromJSON(needs.check-event.outputs.package) }}
+          version: ${{ needs.check-event.outputs.pluginVersion }}
 
       - name: Upload Artifacts 📡
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -71,6 +71,7 @@ jobs:
           
           # For PR builds, use development version to match CMake behavior
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # Use simplified "dev" for artifact naming (CMake will use full semantic version)
             plugin_version="dev"
           else
             plugin_version="$(jq -r '.version' buildspec.json)"

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -75,10 +75,11 @@ jobs:
             base_version="$(jq -r '.version' buildspec.json)"
             IFS='.' read -r major minor patch <<< "${base_version}"
             if [[ -n "${GITHUB_RUN_NUMBER}" ]]; then
-              dev_patch=$((9000 + GITHUB_RUN_NUMBER))
+              run_mod=$((GITHUB_RUN_NUMBER % 1000))  # Limit to 0-999 range
+              dev_patch=$((900 + run_mod))  # Results in 900-1899 range  
               plugin_version="${major}.${minor}.${dev_patch}"
             else
-              plugin_version="${major}.${minor}.9999"
+              plugin_version="${major}.${minor}.999"
             fi
           else
             plugin_version="$(jq -r '.version' buildspec.json)"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -70,6 +70,8 @@ jobs:
 
           root_dir="$(pwd)"
           commit_hash="${GITHUB_SHA:0:9}"
+          # Use the version from the build workflow (ensures consistency with artifacts)
+          version="${{ needs.build-project.outputs.pluginVersion }}"
 
           variants=(
             'windows-x64;zip|exe'
@@ -81,7 +83,8 @@ jobs:
           for variant_data in "${variants[@]}"; do
             IFS=';' read -r variant suffix <<< "${variant_data}"
 
-            candidates=(*-${variant}-${commit_hash}/@(*|*-dbgsym).@(${suffix}))
+            # Look for artifacts with the actual version number from the tag
+            candidates=(*-${version}-${variant}-${commit_hash}/@(*|*-dbgsym).@(${suffix}))
 
             for candidate in "${candidates[@]}"; do
               mv "${candidate}" "${root_dir}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,24 +2,30 @@ cmake_minimum_required(VERSION 3.28...3.30)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/bootstrap.cmake" NO_POLICY_SCOPE)
 
-# Determine authoritative version from git tag first
-execute_process(
-  COMMAND git describe --tags --always --dirty
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_VERSION_TAG
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  ERROR_QUIET
-)
-
-# Extract clean version number from git tag for project version
-if(GIT_VERSION_TAG AND GIT_VERSION_TAG MATCHES "^v?([0-9]+\\.[0-9]+\\.[0-9]+)")
-  # Extract version number from tag (e.g., "v1.2.3" -> "1.2.3", "1.2.3-dirty" -> "1.2.3")
-  string(REGEX REPLACE "^v?([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" AUTHORITATIVE_VERSION "${GIT_VERSION_TAG}")
-  message(STATUS "Using git tag version: ${AUTHORITATIVE_VERSION}")
+# Determine authoritative version from git tag first (skip for PR builds)
+if(DEFINED ENV{GITHUB_EVENT_NAME} AND "$ENV{GITHUB_EVENT_NAME}" STREQUAL "pull_request")
+  # For PR builds, always use "dev" version regardless of git tags
+  set(AUTHORITATIVE_VERSION "dev")
+  message(STATUS "PR build detected, using development version: ${AUTHORITATIVE_VERSION}")
 else()
-  # Fallback to buildspec.json version if no proper git tag is available
-  set(AUTHORITATIVE_VERSION "${_version}")
-  message(STATUS "No git tag found, using buildspec.json version: ${AUTHORITATIVE_VERSION}")
+  execute_process(
+    COMMAND git describe --tags --always --dirty
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_VERSION_TAG
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_QUIET
+  )
+
+  # Extract clean version number from git tag for project version
+  if(GIT_VERSION_TAG AND GIT_VERSION_TAG MATCHES "^v?([0-9]+\\.[0-9]+\\.[0-9]+)")
+    # Extract version number from tag (e.g., "v1.2.3" -> "1.2.3", "1.2.3-dirty" -> "1.2.3")
+    string(REGEX REPLACE "^v?([0-9]+\\.[0-9]+\\.[0-9]+).*" "\\1" AUTHORITATIVE_VERSION "${GIT_VERSION_TAG}")
+    message(STATUS "Using git tag version: ${AUTHORITATIVE_VERSION}")
+  else()
+    # Fallback to buildspec.json version if no proper git tag is available
+    set(AUTHORITATIVE_VERSION "${_version}")
+    message(STATUS "No git tag found, using buildspec.json version: ${AUTHORITATIVE_VERSION}")
+  endif()
 endif()
 
 project(${_name} VERSION ${AUTHORITATIVE_VERSION})
@@ -37,8 +43,8 @@ include(helpers)
 
 add_library(${CMAKE_PROJECT_NAME} MODULE)
 
-# Update buildspec.json with authoritative version if it came from git tag
-if(GIT_VERSION_TAG AND GIT_VERSION_TAG MATCHES "^v?([0-9]+\\.[0-9]+\\.[0-9]+)")
+# Update buildspec.json with authoritative version if it came from git tag (skip for PR builds)
+if(GIT_VERSION_TAG AND GIT_VERSION_TAG MATCHES "^v?([0-9]+\\.[0-9]+\\.[0-9]+)" AND NOT (DEFINED ENV{GITHUB_EVENT_NAME} AND "$ENV{GITHUB_EVENT_NAME}" STREQUAL "pull_request"))
   # Update buildspec.json with the git tag version to keep it in sync
   # Use sed to update only line 41 (the main project version, not dependency versions)
   execute_process(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,13 @@ if(DEFINED ENV{GITHUB_EVENT_NAME} AND "$ENV{GITHUB_EVENT_NAME}" STREQUAL "pull_r
   list(GET version_parts 1 minor)
   
   if(DEFINED ENV{GITHUB_RUN_NUMBER})
-    # Use 9000 + run_number to clearly indicate development builds
-    math(EXPR dev_patch "9000 + $ENV{GITHUB_RUN_NUMBER}")
+    # Use development patch number with limited range to avoid potential issues
+    math(EXPR run_mod "$ENV{GITHUB_RUN_NUMBER} % 1000")  # Limit to 0-999 range
+    math(EXPR dev_patch "900 + ${run_mod}")  # Results in 900-1899 range
     set(AUTHORITATIVE_VERSION "${major}.${minor}.${dev_patch}")
   else()
-    # Local development builds use 9999
-    set(AUTHORITATIVE_VERSION "${major}.${minor}.9999")
+    # Local development builds use 999
+    set(AUTHORITATIVE_VERSION "${major}.${minor}.999")
   endif()
   message(STATUS "PR build detected, using development version: ${AUTHORITATIVE_VERSION}")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(DEFINED ENV{GITHUB_EVENT_NAME} AND "$ENV{GITHUB_EVENT_NAME}" STREQUAL "pull_r
   string(REPLACE "." ";" version_parts "${_version}")
   list(GET version_parts 0 major)
   list(GET version_parts 1 minor)
-  
+
   if(DEFINED ENV{GITHUB_RUN_NUMBER})
     # Use development patch number with limited range to avoid potential issues
     math(EXPR run_mod "$ENV{GITHUB_RUN_NUMBER} % 1000")  # Limit to 0-999 range
@@ -56,9 +56,10 @@ include(helpers)
 
 add_library(${CMAKE_PROJECT_NAME} MODULE)
 
-# Update buildspec.json with authoritative version if it came from git tag (skip for PR builds)
-if(GIT_VERSION_TAG AND GIT_VERSION_TAG MATCHES "^v?([0-9]+\\.[0-9]+\\.[0-9]+)" AND NOT (DEFINED ENV{GITHUB_EVENT_NAME} AND "$ENV{GITHUB_EVENT_NAME}" STREQUAL "pull_request"))
-  # Update buildspec.json with the git tag version to keep it in sync
+# Update buildspec.json with authoritative version for consistent packaging
+# Always update for PR builds (development versions) and tagged releases
+if(AUTHORITATIVE_VERSION)
+  # Update buildspec.json with the calculated version to keep it in sync
   # Use sed to update only line 41 (the main project version, not dependency versions)
   execute_process(
     COMMAND sed -i "41s/\"version\": \"[^\"]*\"/\"version\": \"${AUTHORITATIVE_VERSION}\"/" "${CMAKE_SOURCE_DIR}/buildspec.json"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ if(DEFINED ENV{GITHUB_EVENT_NAME} AND "$ENV{GITHUB_EVENT_NAME}" STREQUAL "pull_r
   list(GET version_parts 1 minor)
   
   if(DEFINED ENV{GITHUB_RUN_NUMBER})
-    # Use 9990 + run_number to clearly indicate development builds
-    math(EXPR dev_patch "9990 + $ENV{GITHUB_RUN_NUMBER}")
+    # Use 9000 + run_number to clearly indicate development builds
+    math(EXPR dev_patch "9000 + $ENV{GITHUB_RUN_NUMBER}")
     set(AUTHORITATIVE_VERSION "${major}.${minor}.${dev_patch}")
   else()
     # Local development builds use 9999

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,17 +4,19 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/bootstrap.cmake" NO_POLICY_SCO
 
 # Determine authoritative version from git tag first (skip for PR builds)
 if(DEFINED ENV{GITHUB_EVENT_NAME} AND "$ENV{GITHUB_EVENT_NAME}" STREQUAL "pull_request")
-  # For PR builds, use development pre-release version
-  # Extract current version and increment minor for next development version
+  # For PR builds, use development version with high patch numbers
+  # Use format MAJOR.MINOR.999X where X is build number (CMake VERSION compliant)
   string(REPLACE "." ";" version_parts "${_version}")
   list(GET version_parts 0 major)
   list(GET version_parts 1 minor)
-  math(EXPR next_minor "${minor} + 1")
   
   if(DEFINED ENV{GITHUB_RUN_NUMBER})
-    set(AUTHORITATIVE_VERSION "${major}.${next_minor}.0-dev.$ENV{GITHUB_RUN_NUMBER}")
+    # Use 9990 + run_number to clearly indicate development builds
+    math(EXPR dev_patch "9990 + $ENV{GITHUB_RUN_NUMBER}")
+    set(AUTHORITATIVE_VERSION "${major}.${minor}.${dev_patch}")
   else()
-    set(AUTHORITATIVE_VERSION "${major}.${next_minor}.0-dev.local")
+    # Local development builds use 9999
+    set(AUTHORITATIVE_VERSION "${major}.${minor}.9999")
   endif()
   message(STATUS "PR build detected, using development version: ${AUTHORITATIVE_VERSION}")
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,12 +60,21 @@ add_library(${CMAKE_PROJECT_NAME} MODULE)
 # Always update for PR builds (development versions) and tagged releases
 if(AUTHORITATIVE_VERSION)
   # Update buildspec.json with the calculated version to keep it in sync
-  # Use sed to update only line 41 (the main project version, not dependency versions)
+  # Use a cross-platform approach with temporary file to avoid sed -i incompatibilities
   execute_process(
-    COMMAND sed -i "41s/\"version\": \"[^\"]*\"/\"version\": \"${AUTHORITATIVE_VERSION}\"/" "${CMAKE_SOURCE_DIR}/buildspec.json"
+    COMMAND sed "41s/\"version\": \"[^\"]*\"/\"version\": \"${AUTHORITATIVE_VERSION}\"/" "${CMAKE_SOURCE_DIR}/buildspec.json"
+    OUTPUT_FILE "${CMAKE_SOURCE_DIR}/buildspec.json.tmp"
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     RESULT_VARIABLE sed_result
   )
+  
+  if(sed_result EQUAL 0)
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E rename "${CMAKE_SOURCE_DIR}/buildspec.json.tmp" "${CMAKE_SOURCE_DIR}/buildspec.json"
+      RESULT_VARIABLE mv_result
+    )
+    set(sed_result ${mv_result})
+  endif()
 
   if(sed_result EQUAL 0)
     message(STATUS "Updated buildspec.json version to: ${AUTHORITATIVE_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,18 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/bootstrap.cmake" NO_POLICY_SCO
 
 # Determine authoritative version from git tag first (skip for PR builds)
 if(DEFINED ENV{GITHUB_EVENT_NAME} AND "$ENV{GITHUB_EVENT_NAME}" STREQUAL "pull_request")
-  # For PR builds, always use "dev" version regardless of git tags
-  set(AUTHORITATIVE_VERSION "dev")
+  # For PR builds, use development pre-release version
+  # Extract current version and increment minor for next development version
+  string(REPLACE "." ";" version_parts "${_version}")
+  list(GET version_parts 0 major)
+  list(GET version_parts 1 minor)
+  math(EXPR next_minor "${minor} + 1")
+  
+  if(DEFINED ENV{GITHUB_RUN_NUMBER})
+    set(AUTHORITATIVE_VERSION "${major}.${next_minor}.0-dev.$ENV{GITHUB_RUN_NUMBER}")
+  else()
+    set(AUTHORITATIVE_VERSION "${major}.${next_minor}.0-dev.local")
+  endif()
   message(STATUS "PR build detected, using development version: ${AUTHORITATIVE_VERSION}")
 else()
   execute_process(

--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
     },
     "name": "c64u-plugin-for-obs",
     "displayName": "Commodore 64 Ultimate Source Plugin for OBS",
-    "version": "0.5.984",
+    "version": "0.5.985",
     "author": "Christian Gleissner",
     "website": "https://c64.gleissner.uk",
     "email": "c64@gleissner.com"

--- a/buildspec.json
+++ b/buildspec.json
@@ -38,7 +38,7 @@
     },
     "name": "c64u-plugin-for-obs",
     "displayName": "Commodore 64 Ultimate Source Plugin for OBS",
-    "version": "0.4.3",
+    "version": "0.5.984",
     "author": "Christian Gleissner",
     "website": "https://c64.gleissner.uk",
     "email": "c64@gleissner.com"


### PR DESCRIPTION
## 🐛 Problem

The 0.5.0 release only produced macOS artifacts instead of the full Windows/Linux/macOS suite that 0.4.3 successfully created. This was a regression in the release process caused by version synchronization issues between the git tag system and artifact collection.

## 🔍 Root Cause

The git tag system dynamically updates `buildspec.json` during CI builds, but:
- Each platform job was independently extracting version from `buildspec.json` 
- The release workflow extracted version from git tags
- This created potential timing and consistency issues between artifact naming and collection patterns

## ✅ Solution

**Centralized Version Management:**
- Enhanced `check-event` job to extract version from `buildspec.json` once as single source of truth
- Updated all platform jobs (macOS, Ubuntu, Windows) to use centralized version
- Modified release workflow to use `build-project` workflow version output for perfect consistency

**Technical Changes:**
- Added `pluginVersion` output to `build-project.yaml` workflow
- Updated platform setup steps to use `${{ needs.check-event.outputs.pluginVersion }}`
- Changed `push.yaml` to use `${{ needs.build-project.outputs.pluginVersion }}` instead of git tag extraction

## 🎯 Expected Results

The next git tag release should:
- ✅ Generate artifacts for **all platforms** (Windows, Linux, macOS)
- ✅ Use consistent version numbers in artifact names  
- ✅ Properly collect and publish all artifacts in GitHub releases
- ✅ Match the successful behavior of release 0.4.3

## 🧪 Testing

- ✅ Local Linux build verification passed
- ✅ Code formatting checks passed  
- ✅ CMake formatting checks passed
- ✅ Git tag version system working correctly (`-- Using git tag version: 0.5.0`)

## 📝 Files Changed

- `.github/workflows/build-project.yaml` - Centralized version extraction and propagation
- `.github/workflows/push.yaml` - Updated to use centralized version from build workflow

This fix ensures perfect synchronization between the git tag version system and the entire CI/CD pipeline for consistent artifact naming and collection across all platforms.